### PR TITLE
Fixed issues with '.' in column headers

### DIFF
--- a/lib/json2xls.js
+++ b/lib/json2xls.js
@@ -1,4 +1,5 @@
 var nodeExcel = require('excel-export');
+var objectPath = require('object-path');
 
 var transform = function(json,config) {
     var conf = transform.prepareJson(json,config);
@@ -27,15 +28,8 @@ function getType(obj,type) {
 function getByString(object, path) {
     path = path.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
     path = path.replace(/^\./, '');           // strip a leading dot
-    var a = path.split('.');
-    while (a.length) {
-        var n = a.shift();
-        if (n in object) {
-            object = (object[n]==undefined)?null:object[n];
-        } else {
-            return null;
-        }
-    }
+    var defaultValue = object[path];
+    object = objectPath.get(object, path, defaultValue);
     return object;
 }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Rikkert Koppes <rikkert@rikkertkoppes.com",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "excel-export": "~0.3.11"
+    "excel-export": "~0.3.11",
+    "object-path": "0.11.4"
   }
 }


### PR DESCRIPTION
Using object-path with a default value for when there are '.' in the column header but it is not a nested object reference