### PR TITLE
fix-bug: colname endswidth '.' will throw an error

### DIFF
--- a/lib/json2xls.js
+++ b/lib/json2xls.js
@@ -25,16 +25,22 @@ function getType(obj,type) {
 
 //get a nested property from a JSON object given its key, i.e 'a.b.c'
 function getByString(object, path) {
+    var originObject = object;
+    var originPath = path;
     path = path.replace(/\[(\w+)\]/g, '.$1'); // convert indexes to properties
     path = path.replace(/^\./, '');           // strip a leading dot
     var a = path.split('.');
-    while (a.length) {
-        var n = a.shift();
-        if (n in object) {
-            object = (object[n]==undefined)?null:object[n];
-        } else {
-            return null;
+    try {
+        while (a.length) {
+            var n = a.shift();
+            if (n in object) {
+                object = (object[n]==undefined)?null:object[n];
+            } else {
+                return null;
+            }
         }
+    } catch (error) {
+        object = (originObject[originPath]==undefined)?null:originObject[originPath];
     }
     return object;
 }


### PR DESCRIPTION
data = [{
        "test": 1,
        "test.": 
}]；

it doesn't work in this case when one of colnames endsWith '.' and  startsWith another colname